### PR TITLE
[CDM] Fix bytesWritten typo at line 32

### DIFF
--- a/libprint/customerdisplaymanager.cpp
+++ b/libprint/customerdisplaymanager.cpp
@@ -29,7 +29,7 @@ using namespace LibG;
 static CustomerDisplayManager *sInstance = nullptr;
 
 CustomerDisplayManager::CustomerDisplayManager(QObject *parent) : QObject(parent) {
-    connect(&mPort, SIGNAL(bytesWritten(qint64)), SLOT(bytesWrittern()));
+    connect(&mPort, SIGNAL(bytesWritten(qint64)), SLOT(bytesWritten()));
 }
 
 void CustomerDisplayManager::bytesWritten() {}


### PR DESCRIPTION
When launching Sultan with currently latest commit you will encounter this error:
`QObject::connect: No such slot LibPrint::CustomerDisplayManager::bytesWrittern() in ../../libprint/customerdisplaymanager.cpp:32`

by fixing the typo the error will no longer appear.
For some reason my second monitor still isn't detected. (Debian 11.4 KDE, Intel HD Graphics, tried Xorg / Wayland and still no luck).
At least 1 error got fixed!